### PR TITLE
fix/lighting-village

### DIFF
--- a/Rebirth/Assets/Scenes/3D Scenes/Store3D.unity
+++ b/Rebirth/Assets/Scenes/3D Scenes/Store3D.unity
@@ -96,7 +96,7 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000000, guid: 5452a05e6c31a8f46b4d382235b9a864, type: 2}
   m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:

--- a/Rebirth/Assets/Scenes/3D Scenes/Village3D.unity
+++ b/Rebirth/Assets/Scenes/3D Scenes/Village3D.unity
@@ -96,7 +96,7 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000000, guid: 5452a05e6c31a8f46b4d382235b9a864, type: 2}
   m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:


### PR DESCRIPTION
# PR Description

### Sprint No. : 2

### Task ID:  https://github.com/2024FALL-SWPP/team-project-for-2024-fall-swpp-team-11/issues/72

### Description
마을에서 다른 scene을 들어갔다가 나올 때 lighting이 달라지는 버그 해결.

## Type of Changes

관련된 사항에 체크해주세요

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 작업
- [ ] 테스트 작업 (테스트 케이스 추가, 테스트 코드 리팩토링)
- [ ] 프로젝트 리팩토링 (프로젝트 구조 수정, 폴더명 수정 등)

# Test

테스트 결과를 명시해주세요.

# Checklist

- [ ] 이 PR의 코드는 프로젝트의 컨벤션을 따릅니다.
- [ ] PR 작성자는 본인 코드에 대한 self-review를 마쳤습니다.
- [ ] 직관적이지 않은, 이해하기 어려운 부분에 대한 주석을 작성하였습니다.
- [ ] 스펙 문서에 해당 변경 사항을 적용했거나, 문서 담당자에게 변경을 요청하였습니다.
- [ ] 코드가 프로젝트에 warning이나 error를 유발하지 않았음을 확인하였습니다.
- [ ] 수정된 기능을 반영한 테스트가 통과하였습니다.
- [ ] 추가된 dependency에 대한 반영을 마쳤습니다.
