### PR TITLE
fix: shopmanager z value

### DIFF
--- a/Rebirth/Assets/Prefabs/GlobalPrefabs/Manager/ShopManager.prefab
+++ b/Rebirth/Assets/Prefabs/GlobalPrefabs/Manager/ShopManager.prefab
@@ -248,7 +248,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881936568039369}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.77862614, y: 0.77862614, z: 0.77862614}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -415,7 +415,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881936716495180}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.77862614, y: 0.77862614, z: 0.77862614}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -550,7 +550,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881936734620370}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.77862614, y: 0.77862614, z: 0.77862614}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1212,7 +1212,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881937334574245}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.77862614, y: 0.77862614, z: 0.77862614}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1493,7 +1493,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881937708842799}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.77862614, y: 0.77862614, z: 0.77862614}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1661,7 +1661,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627881937948104778}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -399.623}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.23358785, y: 0.23358785, z: 0.23358785}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
- change asset names to use addressable system

# PR Description

### Sprint No. : 4

### Task ID: U

### Description
shopmanger의 z value들이 0이 아닌 것들때문에 보이지않아서 수정

## Type of Changes

관련된 사항에 체크해주세요

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 작업
- [ ] 테스트 작업 (테스트 케이스 추가, 테스트 코드 리팩토링)
- [ ] 프로젝트 리팩토링 (프로젝트 구조 수정, 폴더명 수정 등)

# Test
상점씬에서 아이템들이 잘 보임

# Checklist

- [ ] 이 PR의 코드는 프로젝트의 컨벤션을 따릅니다.
- [ ] PR 작성자는 본인 코드에 대한 self-review를 마쳤습니다.
- [ ] 직관적이지 않은, 이해하기 어려운 부분에 대한 주석을 작성하였습니다.
- [ ] 스펙 문서에 해당 변경 사항을 적용했거나, 문서 담당자에게 변경을 요청하였습니다.
- [ ] 코드가 프로젝트에 warning이나 error를 유발하지 않았음을 확인하였습니다.
- [ ] 수정된 기능을 반영한 테스트가 통과하였습니다.
- [ ] 추가된 dependency에 대한 반영을 마쳤습니다.
